### PR TITLE
Main

### DIFF
--- a/playlists/urls.py
+++ b/playlists/urls.py
@@ -13,7 +13,6 @@ urlpatterns = [
 # /playlists/ (list, create)
 # /playlists/{id}/ (retrieve, update, delete)
 # /playlists/{id}/share/ (custom action)
-    path('', include(router.urls)),
     path('playlists/', PlaylistListCreateAPIView.as_view(), name='playlist-list-create'),
     path('playlists/<uuid:pk>/', PlaylistRetrieveUpdateDestroyAPIView.as_view(), name='playlist-detail'), 
     path('playlists/<uuid:playlist_pk>/items/', AddVideoToPlaylistAPIView.as_view(), name='playlist-add-item'),

--- a/playlists/views.py
+++ b/playlists/views.py
@@ -232,4 +232,3 @@ class PlaylistViewSet(viewsets.ModelViewSet):
         playlist.is_public = True
         playlist.save()
         return Response({"message": "Playlist is now public"})
-        return Response({"message": "Playlist is now public"})


### PR DESCRIPTION
This pull request includes several changes to improve code clarity, remove redundant functionality, and streamline routing in the `api` and `playlists` modules. The most important changes include refactoring attribute access in the `list` method, removing the `VideoProgressUpdateView` class, and simplifying playlist URL routing.

### Code clarity improvements:
* [`api/views.py`](diffhunk://#diff-7fb412808754eb12ee1b172c34c44eb9ce58b3bba43d62ffcb986ad7917588a8R39-R54): Refactored the `list` method to use a `try-except` block for accessing `pagination_token` and `prev_token` attributes, ensuring safer attribute access and fallback to `None` if attributes are not set.

### Removal of redundant functionality:
* [`api/views.py`](diffhunk://#diff-7fb412808754eb12ee1b172c34c44eb9ce58b3bba43d62ffcb986ad7917588a8L110-L128): Removed the `VideoProgressUpdateView` class, including its associated methods (`post`, `perform_create`, `get_queryset`, and `perform_update`), as it appears to be unused or redundant.

### Routing simplification:
* [`playlists/urls.py`](diffhunk://#diff-b2d2ad2f68b5b124d07881d72dcf2834a78ca70f390f01031ea07ab464480745L16): Simplified playlist routing by removing the inclusion of `router.urls`, replacing it with explicit paths for playlist-related endpoints.

### Minor cleanup:
* [`playlists/views.py`](diffhunk://#diff-0d4fb3a980c7c346e7d6458517c28362ac52536da13f67511b240bf97949b50aL235): Removed a duplicate line in the `make_public` method that returned a response, ensuring cleaner code.